### PR TITLE
Modernize hpfeeds-logger for Ubuntu 24.04 and Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,32 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
-LABEL maintainer="Team Stingar <team-stingar@duke.edu>"
+LABEL maintainer="n0xa"
 LABEL name="hpfeeds-logger"
-LABEL version="1.9.1"
+LABEL version="2.1.0"
 LABEL release="1"
 LABEL summary="Community Honey Network hpfeeds logger"
 LABEL description="Small app for reading from CHN's hpfeeds3 broker and writing logs"
-LABEL authoritative-source-url="https://github.com/CommunityHoneyNetwork/hpfeeds-logger"
-LABEL changelog-url="https://github.com/CommunityHoneyNetwork/hpfeeds-logger/commits/master"
+LABEL authoritative-source-url="https://github.com/n0xa/hpfeeds-logger"
+LABEL changelog-url="https://github.com/n0xa/hpfeeds-logger/commits/master"
 
 ENV DEBIAN_FRONTEND "noninteractive"
 
 # hadolint ignore=DL3008,DL3005
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install --no-install-recommends -y gcc git python3-dev python3-pip runit libgeoip-dev \
+  && apt-get install --no-install-recommends -y gcc git python3-dev python3-pip python3-venv runit libgeoip-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+# Create virtual environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
 COPY hpfeeds-logger/requirements.txt /opt/requirements.txt
 # hadolint ignore=DL3013
-RUN python3 -m pip install --upgrade pip setuptools wheel \
-  && python3 -m pip install -r /opt/requirements.txt \
-  && python3 -m pip install git+https://github.com/CommunityHoneyNetwork/hpfeeds3.git
+RUN pip install --upgrade pip setuptools wheel \
+  && pip install -r /opt/requirements.txt \
+  && pip install git+https://github.com/n0xa/hpfeeds3.git
 
 RUN mkdir /var/log/hpfeeds-logger
 

--- a/hpfeeds-logger/requirements.txt
+++ b/hpfeeds-logger/requirements.txt
@@ -1,2 +1,2 @@
 GeoIP==1.3.2
-pymongo==2.7.2
+pymongo>=4.0.0


### PR DESCRIPTION
      - Upgrade base image from Ubuntu 18.04 to Ubuntu 24.04
      - Add Python venv
      - Update PyMongo
      - Update hpfeeds3 reference from CommunityHoneyNetwork to n0xa fork